### PR TITLE
Fix five blocking bugs in product-variant / multi-product extraction path

### DIFF
--- a/chemietoolkit/utils.py
+++ b/chemietoolkit/utils.py
@@ -532,7 +532,7 @@ def backout(results, coref_results, molnextr):
         if len(products) == 1:
             if products[0] not in coref_results_dict:
                 print("Warning: No Label Parsed")
-                return
+                return toreturn
             product_labels = coref_results_dict[products[0]]
             prod = products[0]
             label_idx = product_labels[0]
@@ -546,7 +546,7 @@ def backout(results, coref_results, molnextr):
             '''
         else:
             print("Warning: More than one product detected")
-            return
+            return toreturn
         
         # format the regular expression for labels that correspond to the product label
         numbers = re.findall(r'\d+', label_idx)
@@ -755,7 +755,7 @@ def backout_without_coref(results, coref_results, coref_results_dict, coref_smil
         if len(products) == 1:
             if products[0] not in coref_results_dict:
                 print("Warning: No Label Parsed")
-                return
+                return toreturn
             product_labels = coref_results_dict[products[0]]
             prod = products[0]
             label_idx = product_labels[0]
@@ -769,7 +769,7 @@ def backout_without_coref(results, coref_results, coref_results_dict, coref_smil
             '''
         else:
             print("Warning: More than one product detected")
-            return
+            return toreturn
         
         # format the regular expression for labels that correspond to the product label
         numbers = re.findall(r'\d+', label_idx)

--- a/get_R_group_sub_agent.py
+++ b/get_R_group_sub_agent.py
@@ -1335,7 +1335,7 @@ def process_reaction_image_with_product_variant_R_group_OS(
     *,
     model_name: str = "/models/Qwen3-VL-32B-Instruct-AWQ",
     base_url: Optional[str] = "http://localhost:8000/v1",
-    : Optional[str] = None,
+    api_key: Optional[str] = None,
 ) -> dict:
     """
     Aligned with process_reaction_image_with_product_variant_R_group workflow, but uses a local/self-hosted model compatible with OpenAI Chat Completions protocol (such as vLLM or Ollama).

--- a/get_R_group_sub_agent.py
+++ b/get_R_group_sub_agent.py
@@ -569,14 +569,14 @@ def parse_coref_data_with_fallback(data):
                     "smiles": entry["smiles"],
                     "text": entry["sub_text"],
                     #"bbox": entry["bbox"],
-                    "bbox_id": entry["bbox_id"],
+                    "bbox_id": entry.get("bbox_id", ""),
                 }
             else:
                 result_item = {
                     "smiles": entry["smiles"],
                     "texts": ["There is no label or failed to detect, please recheck the image again"],
                     #"bbox": entry["bbox"],
-                    "bbox_id": entry["bbox_id"],
+                    "bbox_id": entry.get("bbox_id", ""),
                 }
             results.append(result_item)
 

--- a/get_R_group_sub_agent.py
+++ b/get_R_group_sub_agent.py
@@ -1031,6 +1031,7 @@ def process_reaction_image_with_product_variant_R_group(image_path: str) -> dict
  
     client = AzureOpenAI(
         =,
+        api_key=API_KEY,
         api_version=API_VERSION,
         azure_endpoint=AZURE_ENDPOINT
     )

--- a/get_reaction_agent.py
+++ b/get_reaction_agent.py
@@ -812,7 +812,7 @@ def _tesseract_ocr_image(image_path: str) -> str:
 
 
 def get_reaction_c(image_path: str) -> dict:
-    raw_prediction = model1.predict_image_file(image_path, molscribe=True, ocr=True)
+    raw_prediction = model1.predict_image_file(image_path, molnextr=True, ocr=True)
     conditions_per_reaction = []
     for reaction in raw_prediction:
         conds = reaction.get('conditions', [])


### PR DESCRIPTION
## Fix five blocking bugs in product-variant / multi-product extraction path

All five are pre-existing upstream bugs unrelated to deployment.

1. **`get_R_group_sub_agent.py:1033`** — `AzureOpenAI(=, ...)` is missing the `api_key=` keyword name, causing `SyntaxError` and making the module un-importable.
2. **`get_R_group_sub_agent.py:1339`** — `process_reaction_image_with_product_variant_R_group_OS()` signature has an anonymous parameter `: Optional[str] = None,` (`SyntaxError`); should be `api_key: Optional[str] = None,` to match the sibling OS function at L1886.
3. **`get_R_group_sub_agent.py:573,580`** — `parse_coref_data_with_fallback()` indexes `entry["bbox_id"]` in the unpaired branch, raising `KeyError` whenever upstream output omits the field. Aligned with the paired branch's `.get("bbox_id", "")`.
4. **`chemietoolkit/utils.py:535,549,758,772`** — `backout()` and `backout_without_coref()` use bare `return` on three early-exit paths and return `None`. Caller `get_R_group_sub_agent.py:1304` immediately runs `backed_out.sort(...)` → `AttributeError: 'NoneType' object has no attribute 'sort'`. Triggered by any figure with more than one product. Changed to `return toreturn` (the empty list initialized at the top of each function).
5. **`get_reaction_agent.py:818`** — passes the old kwarg `molscribe=True` to `RxnIM.predict_image_file()`, but `RxnIM.predict_images()` only accepts `molnextr=` (see `rxnim/interface.py:113`). Renamed to `molnextr=True`. Raises `TypeError` on any substrate-scope panel.

With these fixes the full `process_reaction_image_with_product_variant_R_group` path runs to completion on substrate-scope tables (verified on `examples/1.png`).